### PR TITLE
Swift 2

### DIFF
--- a/DKChainableAnimationKit.xcodeproj/project.pbxproj
+++ b/DKChainableAnimationKit.xcodeproj/project.pbxproj
@@ -181,7 +181,8 @@
 		5287D66B1B1120E6006A9A84 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = DeltaX;
 				TargetAttributes = {
 					5287D6731B1120E6006A9A84 = {
@@ -281,6 +282,7 @@
 				CURRENT_PROJECT_VERSION = 1.3;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -358,6 +360,7 @@
 				INFOPLIST_FILE = DKChainableAnimationKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -373,6 +376,7 @@
 				INFOPLIST_FILE = DKChainableAnimationKit/Info.plist;
 				INSTALL_PATH = "$(LOCAL_LIBRARY_DIR)/Frameworks";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
 			};
@@ -391,6 +395,7 @@
 				);
 				INFOPLIST_FILE = DKChainableAnimationKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Debug;
@@ -404,6 +409,7 @@
 				);
 				INFOPLIST_FILE = DKChainableAnimationKitTests/Info.plist;
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 			};
 			name = Release;

--- a/DKChainableAnimationKit.xcodeproj/xcshareddata/xcschemes/DKChainableAnimationKit.xcscheme
+++ b/DKChainableAnimationKit.xcodeproj/xcshareddata/xcschemes/DKChainableAnimationKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -62,6 +62,8 @@
             ReferencedContainer = "container:DKChainableAnimationKit.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -71,6 +73,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <MacroExpansion>
          <BuildableReference

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
@@ -75,7 +75,7 @@ public class DKChainableAnimationKit {
         }
 
         self.addAnimationCompletionAction { (view: UIView) -> Void in
-            var bounds = CGRect(x: 0, y: 0, width: width, height: height)
+            let bounds = CGRect(x: 0, y: 0, width: width, height: height)
             view.layer.bounds = bounds
             view.bounds = bounds
         }
@@ -193,7 +193,7 @@ public class DKChainableAnimationKit {
     public func makeBorderColor(color: UIColor) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let borderColorAnimation = self.basicAnimationForKeyPath("borderColor")
-            borderColorAnimation.fromValue = UIColor(CGColor: view.layer.borderColor)
+            borderColorAnimation.fromValue = UIColor(CGColor: view.layer.borderColor!)
             borderColorAnimation.toValue = color
             self.addAnimationFromCalculationBlock(borderColorAnimation)
         }
@@ -290,7 +290,7 @@ public class DKChainableAnimationKit {
 
     // MARK: - Anchor
 
-    private func makeAnchorFrom(#x: CGFloat, y: CGFloat) {
+    private func makeAnchorFrom(x x: CGFloat, y: CGFloat) {
         let anchorPoint = CGPoint(x: x, y: y)
         func action(view: UIView) {
             if CGPointEqualToPoint(anchorPoint, view.layer.anchorPoint) {
@@ -1004,14 +1004,14 @@ public class DKChainableAnimationKit {
         return animation
     }
 
-    internal func newPositionFrom(#newOrigin: CGPoint) -> CGPoint {
+    internal func newPositionFrom(newOrigin newOrigin: CGPoint) -> CGPoint {
         let anchor = self.view.layer.anchorPoint
         let size = self.view.bounds.size
         let newPosition = CGPoint(x: newOrigin.x + anchor.x * size.width, y: newOrigin.y + anchor.y * size.height)
         return newPosition
     }
 
-    internal func newPositionFrom(#newCenter: CGPoint) -> CGPoint {
+    internal func newPositionFrom(newCenter newCenter: CGPoint) -> CGPoint {
         let anchor = self.view.layer.anchorPoint
         let size = self.view.bounds.size
         let newPosition = CGPoint(x: newCenter.x + (anchor.x - 0.5) * size.width, y: newCenter.y + (anchor.y - 0.5) * size.height)

--- a/DKChainableAnimationKit/Classes/DKKeyFrameAnimation.swift
+++ b/DKChainableAnimationKit/Classes/DKKeyFrameAnimation.swift
@@ -48,8 +48,8 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
                 self.fromValue.objCType
                 let valueType: NSString! = NSString(CString: self.fromValue.objCType, encoding: 1)
                 if valueType.containsString("CGRect") {
-                    let fromRect = self.fromValue.CGRectValue()
-                    let toRect = self.toValue.CGRectValue()
+                    let fromRect = self.fromValue.CGRectValue
+                    let toRect = self.toValue.CGRectValue
 
                     let xValues = self.valueArrayFor(startValue: fromRect.origin.x, endValue: toRect.origin.x) as! [CGFloat]
                     let yValues = self.valueArrayFor(startValue: fromRect.origin.y, endValue: toRect.origin.x) as! [CGFloat]
@@ -59,8 +59,8 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
                     self.values = self.rectArrayFrom(xValues: xValues, yValues: yValues, widthValues: widthValues, heightValues: heightValues) as [AnyObject]
 
                 } else if valueType.containsString("CGPoint") {
-                    let fromPoint = self.fromValue.CGPointValue()
-                    let toPoint = self.toValue.CGPointValue()
+                    let fromPoint = self.fromValue.CGPointValue
+                    let toPoint = self.toValue.CGPointValue
                     let path = self.createPathFromXYValues(self.valueArrayFor(startValue: fromPoint.x, endValue: toPoint.x), yValues: self.valueArrayFor(startValue: fromPoint.y, endValue: toPoint.y))
                     self.path = path
                 } else if valueType.containsString("CGSize") {
@@ -101,12 +101,12 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
     }
 
     private func createTransformArrayFrom(
-        #m11: NSArray, m12: NSArray, m13: NSArray, m14: NSArray,
+        m11 m11: NSArray, m12: NSArray, m13: NSArray, m14: NSArray,
         m21: NSArray, m22: NSArray, m23: NSArray, m24: NSArray,
         m31: NSArray, m32: NSArray, m33: NSArray, m34: NSArray,
         m41: NSArray, m42: NSArray, m43: NSArray, m44: NSArray) -> NSArray {
             let numberOfTransforms = m11.count;
-            var values = NSMutableArray(capacity: numberOfTransforms)
+            let values = NSMutableArray(capacity: numberOfTransforms)
             var value: CATransform3D!
             for (var i = 1; i < numberOfTransforms; i++) {
                 value = CATransform3DIdentity;
@@ -155,9 +155,9 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
         return self.fromValue.isKindOfClass(klass) && self.toValue.isKindOfClass(klass)
     }
 
-    private func rectArrayFrom(#xValues: [CGFloat], yValues: [CGFloat], widthValues: [CGFloat], heightValues: [CGFloat]) -> NSArray {
+    private func rectArrayFrom(xValues xValues: [CGFloat], yValues: [CGFloat], widthValues: [CGFloat], heightValues: [CGFloat]) -> NSArray {
         let numberOfRects = xValues.count
-        var values: NSMutableArray = []
+        let values: NSMutableArray = []
         var value: NSValue
 
         for i in 1..<numberOfRects {
@@ -168,7 +168,7 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
 
     }
 
-    private func colorArrayFrom(#redValues: [CGFloat], greenValues: [CGFloat], blueValues: [CGFloat], alphaValues: [CGFloat]) -> [CGColor] {
+    private func colorArrayFrom(redValues redValues: [CGFloat], greenValues: [CGFloat], blueValues: [CGFloat], alphaValues: [CGFloat]) -> [CGColor] {
         let numberOfColors = redValues.count
         var values: [CGColor] = []
         var value: CGColor!
@@ -180,7 +180,7 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
         return values
     }
 
-    private func valueArrayFor(#startValue: CGFloat, endValue: CGFloat) -> NSArray {
+    private func valueArrayFor(startValue startValue: CGFloat, endValue: CGFloat) -> NSArray {
         let startValue = Double(startValue)
         let endValue = Double(endValue)
 
@@ -192,7 +192,7 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
 
         var valueArray: [Double] = []
 
-        for i in 0..<steps {
+        for _ in 0..<steps {
             v = self.functionBlock(self.duration * progress * 1000, 0, 1, self.duration * 1000);
             value = startValue + v * (endValue - startValue);
 

--- a/DKChainableAnimationKit/Classes/DKKeyframeAnimationFunction.swift
+++ b/DKChainableAnimationKit/Classes/DKKeyframeAnimationFunction.swift
@@ -94,23 +94,23 @@ func DKKeyframeAnimationFunctionEaseInOutQuint(var t: Double, b: Double, c: Doub
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInSine(var t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInSine(t: Double, b: Double, c: Double, d: Double) -> Double {
     return -c * cos(t / d * (M_PI_2)) + c + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutSine(var t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutSine(t: Double, b: Double, c: Double, d: Double) -> Double {
     return c * sin(t / d * (M_PI_2)) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutSine(var t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutSine(t: Double, b: Double, c: Double, d: Double) -> Double {
     return -c / 2 * (cos(M_PI * t / d) - 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInExpo(var t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInExpo(t: Double, b: Double, c: Double, d: Double) -> Double {
     return (t==0) ? b : c * pow(2, 10 * (t / d - 1)) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutExpo(var t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutExpo(t: Double, b: Double, c: Double, d: Double) -> Double {
 
     return (t == d) ? b+c : c * (-pow(2, -10 * t / d) + 1) + b;
 }
@@ -253,8 +253,8 @@ func DKKeyframeAnimationFunctionEaseInOutBack(var t: Double, b: Double, c: Doubl
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInBounce(var t: Double, b: Double, c: Double, d: Double) -> Double {
-    return c - DKKeyframeAnimationFunctionEaseOutBounce(d - t, 0, c, d) + b;
+func DKKeyframeAnimationFunctionEaseInBounce(t: Double, b: Double, c: Double, d: Double) -> Double {
+    return c - DKKeyframeAnimationFunctionEaseOutBounce(d - t, b: 0, c: c, d: d) + b;
 }
 
 func DKKeyframeAnimationFunctionEaseOutBounce(var t: Double, b: Double, c: Double, d: Double) -> Double {
@@ -273,10 +273,10 @@ func DKKeyframeAnimationFunctionEaseOutBounce(var t: Double, b: Double, c: Doubl
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInOutBounce(var t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutBounce(t: Double, b: Double, c: Double, d: Double) -> Double {
     if t < d / 2 {
-        return DKKeyframeAnimationFunctionEaseInBounce (t * 2, 0, c, d) * 0.5 + b;
+        return DKKeyframeAnimationFunctionEaseInBounce (t * 2, b: 0, c: c, d: d) * 0.5 + b;
     } else {
-        return DKKeyframeAnimationFunctionEaseOutBounce(t * 2 - d, 0, c, d) * 0.5 + c * 0.5 + b;
+        return DKKeyframeAnimationFunctionEaseOutBounce(t * 2 - d, b: 0, c: c, d: d) * 0.5 + c * 0.5 + b;
     }
 }

--- a/DKChainableAnimationKit/Classes/UIView+AnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/UIView+AnimationKit.swift
@@ -20,7 +20,7 @@ public extension UIView {
             } else {
                 animation = DKChainableAnimationKit()
                 animation.view = self
-                objc_setAssociatedObject(self, &animationKitAssociationKey, animation, objc_AssociationPolicy(OBJC_ASSOCIATION_RETAIN))
+                objc_setAssociatedObject(self, &animationKitAssociationKey, animation, .OBJC_ASSOCIATION_RETAIN)
                 return animation
             }
         }

--- a/DKChainableAnimationKit/Info.plist
+++ b/DKChainableAnimationKit/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.draveness.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/DKChainableAnimationKitTests/Info.plist
+++ b/DKChainableAnimationKitTests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.draveness.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/iOS Example Tests/Info.plist
+++ b/iOS Example Tests/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.draveness.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/iOS Example.xcodeproj/project.pbxproj
+++ b/iOS Example.xcodeproj/project.pbxproj
@@ -207,7 +207,8 @@
 		18CEB5B41B059B0300B6ACCB /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastSwiftUpdateCheck = 0700;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = DeltaX;
 				TargetAttributes = {
 					18CEB5BB1B059B0300B6ACCB = {
@@ -355,6 +356,7 @@
 				COPY_PHASE_STRIP = NO;
 				DEBUG_INFORMATION_FORMAT = "dwarf-with-dsym";
 				ENABLE_STRICT_OBJC_MSGSEND = YES;
+				ENABLE_TESTABILITY = YES;
 				GCC_C_LANGUAGE_STANDARD = gnu99;
 				GCC_DYNAMIC_NO_PIC = NO;
 				GCC_NO_COMMON_BLOCKS = YES;
@@ -422,6 +424,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "iOS Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS Example";
 			};
 			name = Debug;
@@ -433,6 +436,7 @@
 				FRAMEWORK_SEARCH_PATHS = "$(inherited)";
 				INFOPLIST_FILE = "iOS Example/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS Example";
 			};
 			name = Release;
@@ -451,6 +455,7 @@
 				);
 				INFOPLIST_FILE = "iOS Example Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS ExampleTests";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example.app/iOS Example";
 			};
@@ -466,6 +471,7 @@
 				);
 				INFOPLIST_FILE = "iOS Example Tests/Info.plist";
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS ExampleTests";
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example.app/iOS Example";
 			};

--- a/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0630"
+   LastUpgradeVersion = "0700"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"
@@ -28,6 +28,16 @@
       shouldUseLaunchSchemeArgsEnv = "YES"
       buildConfiguration = "Debug">
       <Testables>
+         <TestableReference
+            skipped = "NO">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "18CEB5D01B059B0300B6ACCB"
+               BuildableName = "iOS ExampleTests.xctest"
+               BlueprintName = "iOS ExampleTests"
+               ReferencedContainer = "container:iOS Example.xcodeproj">
+            </BuildableReference>
+         </TestableReference>
       </Testables>
       <MacroExpansion>
          <BuildableReference
@@ -38,6 +48,8 @@
             ReferencedContainer = "container:iOS Example.xcodeproj">
          </BuildableReference>
       </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
    </TestAction>
    <LaunchAction
       selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
@@ -47,6 +59,7 @@
       buildConfiguration = "Debug"
       ignoresPersistentStateOnLaunch = "NO"
       debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
       allowLocationSimulation = "YES">
       <BuildableProductRunnable
          runnableDebuggingMode = "0">

--- a/iOS Example/Info.plist
+++ b/iOS Example/Info.plist
@@ -7,7 +7,7 @@
 	<key>CFBundleExecutable</key>
 	<string>$(EXECUTABLE_NAME)</string>
 	<key>CFBundleIdentifier</key>
-	<string>com.draveness.$(PRODUCT_NAME:rfc1034identifier)</string>
+	<string>$(PRODUCT_BUNDLE_IDENTIFIER)</string>
 	<key>CFBundleInfoDictionaryVersion</key>
 	<string>6.0</string>
 	<key>CFBundleName</key>

--- a/iOS Example/ViewController.swift
+++ b/iOS Example/ViewController.swift
@@ -32,7 +32,6 @@ class ViewController: UIViewController {
 
     func animateView(sender: UIButton) {
         sender.userInteractionEnabled = false
-        let purple = UIColor.purpleColor()
         let green = UIColor.greenColor()
 
         v.animation.moveX(100).thenAfter(1.0).moveWidth(50).bounce.makeBackground(green).easeIn.anchorTopLeft.thenAfter(0.5).rotate(95).easeBack.thenAfter(0.5).moveY(300).easeIn.makeOpacity(0.0).animateWithCompletion(0.4, {


### PR DESCRIPTION
Updates DKChainableAnimationKit to the new Swift 2 using Xcode 7 beta1.

I suggest to keep this around as a separate branch `feature/swift-2` and not merge it into master, as it breaks compatibility with Xcode 6 and can only be build using beta software. However, to use DKChainableAnimationKit with the new Xcode and iOS 9 this change is required. Once Xcode 7 leaves beta stage, the branch can then be merged.
