### PR TITLE
prevents crash if view was not set

### DIFF
--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
@@ -187,10 +187,12 @@ public class DKChainableAnimationKit {
             let delayTime = dispatch_time(DISPATCH_TIME_NOW,
                 Int64(delay * Double(NSEC_PER_SEC)))
             dispatch_after(delayTime, dispatch_get_main_queue()) {
-                if let actionCluster: [AnimationCompletionAction] = self.animationCompletionActions.first {
-                    for action in actionCluster {
-                        action(self.view)
-                    }
+                if let
+                    actionCluster: [AnimationCompletionAction] = self.animationCompletionActions.first,
+                    view = self.view {
+                        for action in actionCluster {
+                            action(view)
+                        }
                 }
             }
         }

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
@@ -154,7 +154,7 @@ public class DKChainableAnimationKit {
         self.sanityCheck()
         CATransaction.begin()
         CATransaction.setCompletionBlock { () -> Void in
-            self.view.layer.removeAnimationForKey("AnimationChain")
+            self.view?.layer.removeAnimationForKey("AnimationChain")
             self.chainLinkDidFinishAnimating()
         }
         self.animateChainLink()

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
@@ -165,7 +165,7 @@ public class DKChainableAnimationKit {
 
     private func animateChainLink() {
         self.makeAnchor(0.5, 0.5)
-        if let animationCluster = self.animationCalculationActions.first {
+        if let animationCluster = self.animationCalculationActions.first, let _ = self.view {
             for action in animationCluster {
                 action(self.view)
             }
@@ -177,7 +177,7 @@ public class DKChainableAnimationKit {
                 animation.calculte()
             }
             group.animations = animationCluster
-            self.view.layer.addAnimation(group, forKey: "AnimationChain")
+            self.view?.layer.addAnimation(group, forKey: "AnimationChain")
         }
     }
 


### PR DESCRIPTION
I had created my custom repeat logic and noticed that when I was repeating an animation group I would get this crash because the view at this stage is nil.
