### PR TITLE
Swift 3.0

### DIFF
--- a/DKChainableAnimationKit.xcodeproj/project.pbxproj
+++ b/DKChainableAnimationKit.xcodeproj/project.pbxproj
@@ -198,14 +198,16 @@
 			attributes = {
 				LastSwiftMigration = 0700;
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = DeltaX;
 				TargetAttributes = {
 					5287D6731B1120E6006A9A84 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 					5287D67E1B1120E6006A9A84 = {
 						CreatedOnToolsVersion = 6.3.2;
+						LastSwiftMigration = 0800;
 					};
 				};
 			};
@@ -294,8 +296,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -343,8 +347,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -364,6 +370,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				TARGETED_DEVICE_FAMILY = "1,2";
 				VALIDATE_PRODUCT = YES;
 				VERSIONING_SYSTEM = "apple-generic";
@@ -374,6 +381,7 @@
 		5287D68B1B1120E6006A9A84 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -384,12 +392,14 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
 		5287D68C1B1120E6006A9A84 /* Release */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
+				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "";
 				DEFINES_MODULE = YES;
 				DYLIB_COMPATIBILITY_VERSION = 1;
 				DYLIB_CURRENT_VERSION = 1;
@@ -400,6 +410,7 @@
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
 				SKIP_INSTALL = YES;
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -418,6 +429,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -432,6 +444,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};

--- a/DKChainableAnimationKit.xcodeproj/xcshareddata/xcschemes/DKChainableAnimationKit.xcscheme
+++ b/DKChainableAnimationKit.xcodeproj/xcshareddata/xcschemes/DKChainableAnimationKit.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Anchor.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Anchor.swift
@@ -10,10 +10,10 @@ import UIKit
 
 public extension DKChainableAnimationKit {
 
-    internal func makeAnchorFrom(x x: CGFloat, y: CGFloat) {
+    internal func makeAnchorFrom(x: CGFloat, y: CGFloat) {
         let anchorPoint = CGPoint(x: x, y: y)
-        func action(view: UIView) {
-            if CGPointEqualToPoint(anchorPoint, view.layer.anchorPoint) {
+        func action(_ view: UIView) {
+            if anchorPoint.equalTo(view.layer.anchorPoint) {
                 return
             }
             var newPoint = CGPoint(
@@ -24,8 +24,8 @@ public extension DKChainableAnimationKit {
                 x: view.bounds.size.width * view.layer.anchorPoint.x,
                 y: view.bounds.size.height * view.layer.anchorPoint.y
             )
-            newPoint = CGPointApplyAffineTransform(newPoint, view.transform)
-            oldPoint = CGPointApplyAffineTransform(oldPoint, view.transform)
+            newPoint = newPoint.applying(view.transform)
+            oldPoint = oldPoint.applying(view.transform)
 
             var position = view.layer.position
 
@@ -40,13 +40,13 @@ public extension DKChainableAnimationKit {
         }
 
         if var lastCalculationActions = self.animationCalculationActions.last {
-            lastCalculationActions.insert(action, atIndex: 0)
+            lastCalculationActions.insert(action, at: 0)
             self.animationCalculationActions.removeLast()
             self.animationCalculationActions.append(lastCalculationActions)
         }
     }
 
-    public func makeAnchor(x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
+    @discardableResult public func makeAnchor(_ x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
         self.makeAnchorFrom(x: x, y: y)
         return self
     }

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Bezier.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Bezier.swift
@@ -10,10 +10,10 @@ import UIKit
 
 public extension DKChainableAnimationKit {
 
-    public func moveOnPath(path: UIBezierPath) -> DKChainableAnimationKit {
+    public func moveOnPath(_ path: UIBezierPath) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let pathAnimation = self.basicAnimationForKeyPath("position")
-            pathAnimation.path = path.CGPath
+            pathAnimation.path = path.cgPath
             self.addAnimationFromCalculationBlock(pathAnimation)
         }
 
@@ -24,10 +24,10 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func moveAndRotateOnPath(path: UIBezierPath) -> DKChainableAnimationKit {
+    public func moveAndRotateOnPath(_ path: UIBezierPath) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let pathAnimation = self.basicAnimationForKeyPath("position")
-            pathAnimation.path = path.CGPath
+            pathAnimation.path = path.cgPath
             pathAnimation.rotationMode = kCAAnimationRotateAuto
             self.addAnimationFromCalculationBlock(pathAnimation)
         }
@@ -39,10 +39,10 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func moveAndReverseRotateOnPath(path: UIBezierPath) -> DKChainableAnimationKit {
+    public func moveAndReverseRotateOnPath(_ path: UIBezierPath) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let pathAnimation = self.basicAnimationForKeyPath("position")
-            pathAnimation.path = path.CGPath
+            pathAnimation.path = path.cgPath
             pathAnimation.rotationMode = kCAAnimationRotateAutoReverse
             self.addAnimationFromCalculationBlock(pathAnimation)
         }

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Effects.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Effects.swift
@@ -13,42 +13,42 @@ public extension DKChainableAnimationKit {
 
     public var easeIn: DKChainableAnimationKit {
         get {
-            self.easeInQuad
+            _ = self.easeInQuad
             return self
         }
     }
 
     public var easeOut: DKChainableAnimationKit {
         get {
-            self.easeOutQuad
+            _ = self.easeOutQuad
             return self
         }
     }
 
     public var easeInOut: DKChainableAnimationKit {
         get {
-            self.easeInOutQuad
+            _ = self.easeInOutQuad
             return self
         }
     }
 
     public var easeBack: DKChainableAnimationKit {
         get {
-            self.easeOutBack
+            _ = self.easeOutBack
             return self
         }
     }
 
     public var spring: DKChainableAnimationKit {
         get {
-            self.easeOutElastic
+            _ = self.easeOutElastic
             return self
         }
     }
 
     public var bounce: DKChainableAnimationKit {
         get {
-            self.easeOutBounce
+            _ = self.easeOutBounce
             return self
         }
     }

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Extra.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Extra.swift
@@ -10,11 +10,11 @@ import Foundation
 
 public extension DKChainableAnimationKit {
 
-    public func makeOpacity(opacity: CGFloat) -> DKChainableAnimationKit {
+    public func makeOpacity(_ opacity: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let opacityAnimation = self.basicAnimationForKeyPath("opacity")
-            opacityAnimation.fromValue = view.alpha
-            opacityAnimation.toValue = opacity
+            opacityAnimation.fromValue = view.alpha as AnyObject!
+            opacityAnimation.toValue = opacity as AnyObject!
             self.addAnimationFromCalculationBlock(opacityAnimation)
         }
 
@@ -24,11 +24,11 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeAlpha(alpha: CGFloat) -> DKChainableAnimationKit {
+    public func makeAlpha(_ alpha: CGFloat) -> DKChainableAnimationKit {
         return makeOpacity(alpha)
     }
 
-    public func makeBackground(color: UIColor) -> DKChainableAnimationKit {
+    public func makeBackground(_ color: UIColor) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let backgroundColorAnimation = self.basicAnimationForKeyPath("backgroundColor")
             backgroundColorAnimation.fromValue = view.backgroundColor
@@ -42,26 +42,26 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeBorderColor(color: UIColor) -> DKChainableAnimationKit {
+    public func makeBorderColor(_ color: UIColor) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let borderColorAnimation = self.basicAnimationForKeyPath("borderColor")
-            borderColorAnimation.fromValue = UIColor(CGColor: view.layer.borderColor!)
+            borderColorAnimation.fromValue = UIColor(cgColor: view.layer.borderColor!)
             borderColorAnimation.toValue = color
             self.addAnimationFromCalculationBlock(borderColorAnimation)
         }
 
         self.addAnimationCompletionAction { (view: UIView) -> Void in
-            view.layer.borderColor = color.CGColor
+            view.layer.borderColor = color.cgColor
         }
         return self
     }
 
-    public func makeBorderWidth(width: CGFloat) -> DKChainableAnimationKit {
+    public func makeBorderWidth(_ width: CGFloat) -> DKChainableAnimationKit {
         let width = max(0, width)
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let borderColorAnimation = self.basicAnimationForKeyPath("borderWidth")
-            borderColorAnimation.fromValue = view.layer.borderWidth
-            borderColorAnimation.toValue = width
+            borderColorAnimation.fromValue = view.layer.borderWidth as AnyObject!
+            borderColorAnimation.toValue = width as AnyObject!
             self.addAnimationFromCalculationBlock(borderColorAnimation)
         }
 
@@ -71,12 +71,12 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeCornerRadius(cornerRadius: CGFloat) -> DKChainableAnimationKit {
+    public func makeCornerRadius(_ cornerRadius: CGFloat) -> DKChainableAnimationKit {
         let cornerRadius = max(0, cornerRadius)
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let cornerRadiusAnimation = self.basicAnimationForKeyPath("cornerRadius")
-            cornerRadiusAnimation.fromValue = view.layer.cornerRadius
-            cornerRadiusAnimation.toValue = cornerRadius
+            cornerRadiusAnimation.fromValue = view.layer.cornerRadius as AnyObject!
+            cornerRadiusAnimation.toValue = cornerRadius as AnyObject!
             self.addAnimationFromCalculationBlock(cornerRadiusAnimation)
         }
 

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Frame.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Frame.swift
@@ -10,30 +10,30 @@ import Foundation
 
 public extension DKChainableAnimationKit {
 
-    public func makeFrame(rect: CGRect) -> DKChainableAnimationKit {
+    public func makeFrame(_ rect: CGRect) -> DKChainableAnimationKit {
         return self.makeOrigin(rect.origin.x, rect.origin.y).makeBounds(rect)
     }
 
-    public func makeFrame(x: CGFloat, _ y: CGFloat, _ width: CGFloat, _ height: CGFloat) -> DKChainableAnimationKit {
+    public func makeFrame(_ x: CGFloat, _ y: CGFloat, _ width: CGFloat, _ height: CGFloat) -> DKChainableAnimationKit {
         let rect = CGRect(x: x, y: y, width: width, height: height)
         return self.makeOrigin(x, y).makeBounds(rect)
     }
 
-    public func makeBounds(rect: CGRect) -> DKChainableAnimationKit {
+    public func makeBounds(_ rect: CGRect) -> DKChainableAnimationKit {
         return self.makeSize(rect.size.width, rect.size.height)
     }
 
-    public func makeBounds(x: CGFloat, _ y: CGFloat, _ width: CGFloat, _ height: CGFloat) -> DKChainableAnimationKit {
+    public func makeBounds(_ x: CGFloat, _ y: CGFloat, _ width: CGFloat, _ height: CGFloat) -> DKChainableAnimationKit {
         return self.makeSize(width, height)
     }
 
 
-    public func makeSize(width: CGFloat, _ height: CGFloat) -> DKChainableAnimationKit {
+    public func makeSize(_ width: CGFloat, _ height: CGFloat) -> DKChainableAnimationKit {
 
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let sizeAnimation = self.basicAnimationForKeyPath("bounds.size")
-            sizeAnimation.fromValue = NSValue(CGSize: view.layer.bounds.size)
-            sizeAnimation.toValue = NSValue(CGSize: CGSize(width: width, height: height))
+            sizeAnimation.fromValue = NSValue(cgSize: view.layer.bounds.size)
+            sizeAnimation.toValue = NSValue(cgSize: CGSize(width: width, height: height))
             self.addAnimationFromCalculationBlock(sizeAnimation)
         }
 
@@ -45,12 +45,12 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeOrigin(x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
+    public func makeOrigin(_ x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position")
             let newPosition = self.newPositionFrom(newOrigin: CGPoint(x: x, y: y))
-            positionAnimation.fromValue = NSValue(CGPoint: view.layer.position)
-            positionAnimation.toValue = NSValue(CGPoint: newPosition)
+            positionAnimation.fromValue = NSValue(cgPoint: view.layer.position)
+            positionAnimation.toValue = NSValue(cgPoint: newPosition)
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -62,12 +62,12 @@ public extension DKChainableAnimationKit {
 
     }
 
-    public func makeCenter(x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
+    public func makeCenter(_ x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position")
             let newPosition = self.newPositionFrom(newCenter: CGPoint(x: x, y: y))
-            positionAnimation.fromValue = NSValue(CGPoint: view.layer.position)
-            positionAnimation.toValue = NSValue(CGPoint: newPosition)
+            positionAnimation.fromValue = NSValue(cgPoint: view.layer.position)
+            positionAnimation.toValue = NSValue(cgPoint: newPosition)
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -77,12 +77,12 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeX(x: CGFloat) -> DKChainableAnimationKit {
+    public func makeX(_ x: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position.x")
             let newPosition = self.newPositionFrom(newOrigin: CGPoint(x: x, y: view.layer.frame.origin.y))
-            positionAnimation.fromValue = view.layer.position.x
-            positionAnimation.toValue = newPosition.x
+            positionAnimation.fromValue = view.layer.position.x as AnyObject!
+            positionAnimation.toValue = newPosition.x as AnyObject!
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -93,12 +93,12 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeY(y: CGFloat) -> DKChainableAnimationKit {
+    public func makeY(_ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position.y")
             let newPosition = self.newPositionFrom(newOrigin: CGPoint(x: view.layer.frame.origin.x, y: y))
-            positionAnimation.fromValue = view.layer.position.y
-            positionAnimation.toValue = newPosition.y
+            positionAnimation.fromValue = view.layer.position.y as AnyObject!
+            positionAnimation.toValue = newPosition.y as AnyObject!
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -109,29 +109,29 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeCenterX(x: CGFloat) -> DKChainableAnimationKit {
+    public func makeCenterX(_ x: CGFloat) -> DKChainableAnimationKit {
         return self.makeX(x - view.bounds.size.width / 2)
     }
 
-    public func makeCenterY(y: CGFloat) -> DKChainableAnimationKit {
+    public func makeCenterY(_ y: CGFloat) -> DKChainableAnimationKit {
         return self.makeY(y - view.bounds.size.height / 2)
     }
 
-    public func makeWidth(width: CGFloat) -> DKChainableAnimationKit {
+    public func makeWidth(_ width: CGFloat) -> DKChainableAnimationKit {
         return self.makeSize(width, self.view.layer.frame.size.height)
     }
 
-    public func makeHeight(height: CGFloat) -> DKChainableAnimationKit {
+    public func makeHeight(_ height: CGFloat) -> DKChainableAnimationKit {
         return self.makeSize(self.view.layer.frame.size.width, height)
     }
 
-    public func makeScale(scale: CGFloat) -> DKChainableAnimationKit {
+    public func makeScale(_ scale: CGFloat) -> DKChainableAnimationKit {
         let scale = max(0, scale)
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let scaleAnimation = self.basicAnimationForKeyPath("bounds")
             let rect = CGRect(x: 0, y: 0, width: max(view.bounds.size.width * scale, 0), height: max(view.bounds.size.height * scale, 0))
-            scaleAnimation.fromValue = NSValue(CGRect: view.layer.bounds)
-            scaleAnimation.toValue = NSValue(CGRect: rect)
+            scaleAnimation.fromValue = NSValue(cgRect: view.layer.bounds)
+            scaleAnimation.toValue = NSValue(cgRect: rect)
             self.addAnimationFromCalculationBlock(scaleAnimation)
         }
 
@@ -143,13 +143,13 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeScaleX(xScale: CGFloat) -> DKChainableAnimationKit {
+    public func makeScaleX(_ xScale: CGFloat) -> DKChainableAnimationKit {
         let xScale = max(0, xScale)
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let scaleAnimation = self.basicAnimationForKeyPath("bounds")
             let rect = CGRect(x: 0, y: 0, width: view.bounds.size.width, height: max(view.bounds.size.height * xScale, 0))
-            scaleAnimation.fromValue = NSValue(CGRect: view.layer.bounds)
-            scaleAnimation.toValue = NSValue(CGRect: rect)
+            scaleAnimation.fromValue = NSValue(cgRect: view.layer.bounds)
+            scaleAnimation.toValue = NSValue(cgRect: rect)
             self.addAnimationFromCalculationBlock(scaleAnimation)
         }
 
@@ -161,13 +161,13 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func makeScaleY(yScale: CGFloat) -> DKChainableAnimationKit {
+    public func makeScaleY(_ yScale: CGFloat) -> DKChainableAnimationKit {
         let yScale = max(0, yScale)
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let scaleAnimation = self.basicAnimationForKeyPath("bounds")
             let rect = CGRect(x: 0, y: 0, width: max(view.bounds.size.width * yScale, 0), height: view.bounds.size.height)
-            scaleAnimation.fromValue = NSValue(CGRect: view.layer.bounds)
-            scaleAnimation.toValue = NSValue(CGRect: rect)
+            scaleAnimation.fromValue = NSValue(cgRect: view.layer.bounds)
+            scaleAnimation.toValue = NSValue(cgRect: rect)
             self.addAnimationFromCalculationBlock(scaleAnimation)
         }
 
@@ -182,11 +182,11 @@ public extension DKChainableAnimationKit {
 
     // MARK: - Move
 
-    public func moveX(x: CGFloat) -> DKChainableAnimationKit {
+    public func moveX(_ x: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position.x")
-            positionAnimation.fromValue = view.layer.position.x
-            positionAnimation.toValue = view.layer.position.x + x
+            positionAnimation.fromValue = view.layer.position.x as AnyObject!
+            positionAnimation.toValue = (view.layer.position.x + x) as AnyObject!
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -198,11 +198,11 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func moveY(y: CGFloat) -> DKChainableAnimationKit {
+    public func moveY(_ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position.y")
-            positionAnimation.fromValue = view.layer.position.y
-            positionAnimation.toValue = view.layer.position.y + y
+            positionAnimation.fromValue = view.layer.position.y as AnyObject!
+            positionAnimation.toValue = (view.layer.position.y + y) as AnyObject!
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -214,13 +214,13 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func moveXY(x :CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
+    public func moveXY(_ x :CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("position")
             let oldOrigin = view.layer.frame.origin
             let newPosition = CGPoint(x: view.layer.position.x + x, y: view.layer.position.y + y)
-            positionAnimation.fromValue = NSValue(CGPoint: oldOrigin)
-            positionAnimation.toValue = NSValue(CGPoint: newPosition)
+            positionAnimation.fromValue = NSValue(cgPoint: oldOrigin)
+            positionAnimation.toValue = NSValue(cgPoint: newPosition)
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
@@ -233,43 +233,43 @@ public extension DKChainableAnimationKit {
         return self
     }
 
-    public func moveHeight(height: CGFloat) -> DKChainableAnimationKit {
+    public func moveHeight(_ height: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("bounds.size")
             let newSize = CGSize(width: view.layer.bounds.size.width, height: max(view.layer.bounds.size.width + height, 0))
-            positionAnimation.fromValue = NSValue(CGSize: view.layer.bounds.size)
-            positionAnimation.toValue = NSValue(CGSize: newSize)
+            positionAnimation.fromValue = NSValue(cgSize: view.layer.bounds.size)
+            positionAnimation.toValue = NSValue(cgSize: newSize)
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
         self.addAnimationCompletionAction { (view: UIView) -> Void in
             let newSize = CGSize(width: view.layer.bounds.size.width, height: max(view.layer.bounds.size.width + height, 0))
-            let bounds = CGRect(origin: CGPointZero, size: newSize)
+            let bounds = CGRect(origin: CGPoint.zero, size: newSize)
             view.layer.bounds = bounds
             view.bounds = bounds
         }
         return self
     }
 
-    public func moveWidth(width: CGFloat) -> DKChainableAnimationKit {
+    public func moveWidth(_ width: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let positionAnimation = self.basicAnimationForKeyPath("bounds.size")
             let newSize = CGSize(width: max(view.layer.bounds.size.width + width, 0), height: view.layer.bounds.size.height)
-            positionAnimation.fromValue = NSValue(CGSize: view.layer.bounds.size)
-            positionAnimation.toValue = NSValue(CGSize: newSize)
+            positionAnimation.fromValue = NSValue(cgSize: view.layer.bounds.size)
+            positionAnimation.toValue = NSValue(cgSize: newSize)
             self.addAnimationFromCalculationBlock(positionAnimation)
         }
 
         self.addAnimationCompletionAction { (view: UIView) -> Void in
             let newSize = CGSize(width: max(view.layer.bounds.size.width + width, 0), height: view.layer.bounds.size.height)
-            let bounds = CGRect(origin: CGPointZero, size: newSize)
+            let bounds = CGRect(origin: CGPoint.zero, size: newSize)
             view.layer.bounds = bounds
             view.bounds = bounds
         }
         return self
     }
 
-    public func movePolar(radius: Double, _ angle: Double) -> DKChainableAnimationKit {
+    public func movePolar(_ radius: Double, _ angle: Double) -> DKChainableAnimationKit {
         let radians  = self.degreesToRadians(angle)
         let x = CGFloat(radius * cos(radians))
         let y = CGFloat(-radius * sin(radians))

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Transform.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit+Transform.swift
@@ -15,8 +15,8 @@ extension DKChainableAnimationKit {
             self.addAnimationCalculationAction { (view: UIView) -> Void in
                 let transformAnimation = self.basicAnimationForKeyPath("transform")
                 let transform = CATransform3DIdentity
-                transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-                transformAnimation.toValue = NSValue(CATransform3D: transform)
+                transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+                transformAnimation.toValue = NSValue(caTransform3D: transform)
                 self.addAnimationFromCalculationBlock(transformAnimation)
             }
             self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -27,13 +27,13 @@ extension DKChainableAnimationKit {
         }
     }
 
-    public func transformX(x: CGFloat) -> DKChainableAnimationKit {
+    public func transformX(_ x: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DTranslate(transform, x, 0, 0)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -44,13 +44,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func transformY(y: CGFloat) -> DKChainableAnimationKit {
+    public func transformY(_ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DTranslate(transform, 0, y, 0)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -61,13 +61,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func transformZ(z: CGFloat) -> DKChainableAnimationKit {
+    public func transformZ(_ z: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DTranslate(transform, 0, 0, z)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -78,13 +78,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func transformXY(x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
+    public func transformXY(_ x: CGFloat, _ y: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DTranslate(transform, x, y, 0)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -95,13 +95,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func transformScale(scale: CGFloat) -> DKChainableAnimationKit {
+    public func transformScale(_ scale: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DScale(transform, scale, scale, 1)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -112,13 +112,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func transformScaleX(scaleX: CGFloat) -> DKChainableAnimationKit {
+    public func transformScaleX(_ scaleX: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DScale(transform, scaleX, 1, 1)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -129,13 +129,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func transformScaleY(scaleY: CGFloat) -> DKChainableAnimationKit {
+    public func transformScaleY(_ scaleY: CGFloat) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let transformAnimation = self.basicAnimationForKeyPath("transform")
             var transform = view.layer.transform
             transform = CATransform3DScale(transform, 1, scaleY, 1)
-            transformAnimation.fromValue = NSValue(CATransform3D: view.layer.transform)
-            transformAnimation.toValue = NSValue(CATransform3D: transform)
+            transformAnimation.fromValue = NSValue(caTransform3D: view.layer.transform)
+            transformAnimation.toValue = NSValue(caTransform3D: transform)
             self.addAnimationFromCalculationBlock(transformAnimation)
         }
         self.addAnimationCompletionAction { (view: UIView) -> Void in
@@ -146,13 +146,13 @@ extension DKChainableAnimationKit {
         return self
     }
 
-    public func rotate(angle: Double) -> DKChainableAnimationKit {
+    public func rotate(_ angle: Double) -> DKChainableAnimationKit {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let rotationAnimation = self.basicAnimationForKeyPath("transform.rotation")
             let transform = view.layer.transform
             let originalRotation = Double(atan2(transform.m12, transform.m11))
-            rotationAnimation.fromValue = originalRotation
-            rotationAnimation.toValue = originalRotation + self.degreesToRadians(angle)
+            rotationAnimation.fromValue = originalRotation as AnyObject!
+            rotationAnimation.toValue = (originalRotation + self.degreesToRadians(angle)) as AnyObject!
             self.addAnimationFromCalculationBlock(rotationAnimation)
         }
 

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
@@ -81,7 +81,7 @@ open class DKChainableAnimationKit {
         return self
     }
 
-    open func animate(_ duration: CGFloat) -> DKChainableAnimationKit {
+    @discardableResult open func animate(_ duration: CGFloat) -> DKChainableAnimationKit {
         return animate(TimeInterval(duration))
     }
 
@@ -142,7 +142,7 @@ open class DKChainableAnimationKit {
         return self
     }
 
-    open func animateWithCompletion(_ duration: CGFloat, _ completion: @escaping (Void) -> Void) -> DKChainableAnimationKit {
+    @discardableResult open func animateWithCompletion(_ duration: CGFloat, _ completion: @escaping (Void) -> Void) -> DKChainableAnimationKit {
         return animateWithCompletion(TimeInterval(duration), completion)
     }
 

--- a/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/DKChainableAnimationKit.swift
@@ -8,18 +8,18 @@
 
 import UIKit
 
-public class DKChainableAnimationKit {
+open class DKChainableAnimationKit {
 
     weak var view: UIView!
 
-    typealias AnimationCalculationAction = UIView -> Void
-    typealias AnimationCompletionAction = UIView -> Void
+    typealias AnimationCalculationAction = (UIView) -> Void
+    typealias AnimationCompletionAction = (UIView) -> Void
 
     internal var animationCalculationActions: [[AnimationCalculationAction]]!
     internal var animationCompletionActions: [[AnimationCompletionAction]]!
     internal var animationGroups: NSMutableArray!
     internal var animations: [[DKKeyFrameAnimation]]!
-    public var animationCompletion: (Void -> Void)?
+    open var animationCompletion: ((Void) -> Void)?
 
     // MARK: - Initialize
 
@@ -27,14 +27,14 @@ public class DKChainableAnimationKit {
         self.setup()
     }
 
-    private func setup() {
+    fileprivate func setup() {
         self.animations = [[]]
         self.animationGroups = [self.basicAnimationGroup()]
         self.animationCompletionActions = [[]]
         self.animationCalculationActions = [[]]
     }
 
-    private func clear() {
+    fileprivate func clear() {
         self.animations.removeAll()
         self.animationGroups.removeAllObjects()
         self.animationCompletionActions.removeAll()
@@ -42,15 +42,15 @@ public class DKChainableAnimationKit {
         self.animations.append([])
         self.animationCompletionActions.append([AnimationCalculationAction]())
         self.animationCalculationActions.append([AnimationCompletionAction]())
-        self.animationGroups.addObject(self.basicAnimationGroup())
+        self.animationGroups.add(self.basicAnimationGroup())
     }
 
     // MARK: - Animation Time
 
-    public func delay(delay: NSTimeInterval) -> DKChainableAnimationKit {
+    open func delay(_ delay: TimeInterval) -> DKChainableAnimationKit {
         var delay = delay
         for group in self.animationGroups {
-            let duration = group.duration as NSTimeInterval
+            let duration = (group as AnyObject).duration as TimeInterval
             delay += duration
         }
         if let group = self.animationGroups.lastObject as? CAAnimationGroup {
@@ -59,21 +59,21 @@ public class DKChainableAnimationKit {
         return self
     }
 
-    public func delay(time: CGFloat) -> DKChainableAnimationKit {
-        return delay(NSTimeInterval(time))
+    open func delay(_ time: CGFloat) -> DKChainableAnimationKit {
+        return delay(TimeInterval(time))
     }
 
-    public var seconds: DKChainableAnimationKit {
+    open var seconds: DKChainableAnimationKit {
         get {
             return self
         }
     }
 
-    public func wait(delay: NSTimeInterval) -> DKChainableAnimationKit {
+    open func wait(_ delay: TimeInterval) -> DKChainableAnimationKit {
         return self.delay(delay)
     }
 
-    public func animate(duration: NSTimeInterval) -> DKChainableAnimationKit {
+    @discardableResult open func animate(_ duration: TimeInterval) -> DKChainableAnimationKit {
         if let group = self.animationGroups.lastObject as? CAAnimationGroup {
             group.duration = duration
             self.animateChain()
@@ -81,8 +81,8 @@ public class DKChainableAnimationKit {
         return self
     }
 
-    public func animate(duration: CGFloat) -> DKChainableAnimationKit {
-        return animate(NSTimeInterval(duration))
+    open func animate(_ duration: CGFloat) -> DKChainableAnimationKit {
+        return animate(TimeInterval(duration))
     }
 
 //    public func animateWithRepeat(duration: NSTimeInterval) -> DKChainableAnimationKit {
@@ -117,11 +117,11 @@ public class DKChainableAnimationKit {
 //        self.animations = self.tempAnimations
 //    }
 
-    public func thenAfter(after: NSTimeInterval) -> DKChainableAnimationKit {
+    open func thenAfter(_ after: TimeInterval) -> DKChainableAnimationKit {
         if let group = self.animationGroups.lastObject as? CAAnimationGroup {
             group.duration = after
             let newGroup = self.basicAnimationGroup()
-            self.animationGroups.addObject(newGroup)
+            self.animationGroups.add(newGroup)
             self.animations.append([])
             self.animationCalculationActions.append([])
             self.animationCompletionActions.append([])
@@ -129,11 +129,11 @@ public class DKChainableAnimationKit {
         return self
     }
 
-    public func thenAfter(after: CGFloat) -> DKChainableAnimationKit {
-        return thenAfter(NSTimeInterval(after))
+    open func thenAfter(_ after: CGFloat) -> DKChainableAnimationKit {
+        return thenAfter(TimeInterval(after))
     }
 
-    public func animateWithCompletion(duration: NSTimeInterval, _ completion: Void -> Void) -> DKChainableAnimationKit {
+    @discardableResult open func animateWithCompletion(_ duration: TimeInterval, _ completion: @escaping (Void) -> Void) -> DKChainableAnimationKit {
         if let group = self.animationGroups.lastObject as? CAAnimationGroup {
             group.duration = duration
             self.animationCompletion = completion
@@ -142,19 +142,19 @@ public class DKChainableAnimationKit {
         return self
     }
 
-    public func animateWithCompletion(duration: CGFloat, _ completion: Void -> Void) -> DKChainableAnimationKit {
-        return animateWithCompletion(NSTimeInterval(duration), completion)
+    open func animateWithCompletion(_ duration: CGFloat, _ completion: @escaping (Void) -> Void) -> DKChainableAnimationKit {
+        return animateWithCompletion(TimeInterval(duration), completion)
     }
 
-    internal func degreesToRadians(degree: Double) -> Double {
+    internal func degreesToRadians(_ degree: Double) -> Double {
         return (degree / 180.0) * M_PI
     }
 
-    private func animateChain() {
+    fileprivate func animateChain() {
         self.sanityCheck()
         CATransaction.begin()
         CATransaction.setCompletionBlock { () -> Void in
-            self.view?.layer.removeAnimationForKey("AnimationChain")
+            self.view?.layer.removeAnimation(forKey: "AnimationChain")
             self.chainLinkDidFinishAnimating()
         }
         self.animateChainLink()
@@ -163,7 +163,7 @@ public class DKChainableAnimationKit {
         self.executeCompletionActions()
     }
 
-    private func animateChainLink() {
+    fileprivate func animateChainLink() {
         self.makeAnchor(0.5, 0.5)
         if let animationCluster = self.animationCalculationActions.first, let _ = self.view {
             for action in animationCluster {
@@ -171,25 +171,24 @@ public class DKChainableAnimationKit {
             }
         }
         if let group: CAAnimationGroup = self.animationGroups.firstObject as? CAAnimationGroup,
-            animationCluster: [DKKeyFrameAnimation] = self.animations.first {
+            let animationCluster: [DKKeyFrameAnimation] = self.animations.first {
             for animation in animationCluster {
                 animation.duration = group.duration
                 animation.calculte()
             }
             group.animations = animationCluster
-            self.view?.layer.addAnimation(group, forKey: "AnimationChain")
+            self.view?.layer.add(group, forKey: "AnimationChain")
         }
     }
 
-    private func executeCompletionActions() {
+    fileprivate func executeCompletionActions() {
         if let group = self.animationGroups.firstObject as? CAAnimationGroup {
             let delay = max(group.beginTime - CACurrentMediaTime(), 0.0)
-            let delayTime = dispatch_time(DISPATCH_TIME_NOW,
-                Int64(delay * Double(NSEC_PER_SEC)))
-            dispatch_after(delayTime, dispatch_get_main_queue()) {
+            let delayTime = DispatchTime.now() + Double(Int64(delay * Double(NSEC_PER_SEC))) / Double(NSEC_PER_SEC)
+            DispatchQueue.main.asyncAfter(deadline: delayTime) {
                 if let
                     actionCluster: [AnimationCompletionAction] = self.animationCompletionActions.first,
-                    view = self.view {
+                    let view = self.view {
                         for action in actionCluster {
                             action(view)
                         }
@@ -198,11 +197,11 @@ public class DKChainableAnimationKit {
         }
     }
 
-    private func chainLinkDidFinishAnimating() {
-        self.animationCompletionActions.removeAtIndex(0)
-        self.animationCalculationActions.removeAtIndex(0)
-        self.animations.removeAtIndex(0)
-        self.animationGroups.removeObjectAtIndex(0)
+    fileprivate func chainLinkDidFinishAnimating() {
+        self.animationCompletionActions.remove(at: 0)
+        self.animationCalculationActions.remove(at: 0)
+        self.animations.remove(at: 0)
+        self.animationGroups.removeObject(at: 0)
 
         if self.animationGroups.count == 0 {
             self.clear()
@@ -215,7 +214,7 @@ public class DKChainableAnimationKit {
         }
     }
 
-    private func sanityCheck() {
+    fileprivate func sanityCheck() {
         assert(self.animations.count == self.animationGroups.count, "FATAL ERROR: ANIMATION GROUPS AND ANIMATIONS ARE OUT OF SYNC");
         assert(self.animationCalculationActions.count == self.animationCompletionActions.count, "FATAL ERROR: ANIMATION CALCULATION OBJECTS AND ANIMATION COMPLETION OBJECTS ARE OUT OF SYNC");
         assert(self.animations.count == self.animationCompletionActions.count, "FATAL ERROR: ANIMATIONS AND ANIMATION COMPLETION OBJECTS ARE OUT OF SYNC");
@@ -223,7 +222,7 @@ public class DKChainableAnimationKit {
 
     // MARK: - Animation Action
 
-    internal func addAnimationKeyframeCalculation(functionBlock: DKKeyframeAnimationFunctionBlock) {
+    internal func addAnimationKeyframeCalculation(_ functionBlock: @escaping DKKeyframeAnimationFunctionBlock) {
         self.addAnimationCalculationAction { (view: UIView) -> Void in
             let animationCluster = self.animations.first
             if let animation = animationCluster?.last {
@@ -232,7 +231,7 @@ public class DKChainableAnimationKit {
         }
     }
 
-    internal func addAnimationCalculationAction(action: AnimationCalculationAction) {
+    internal func addAnimationCalculationAction(_ action: @escaping AnimationCalculationAction) {
         if var actions = self.animationCalculationActions.last as [AnimationCalculationAction]? {
             actions.append(action)
             self.animationCalculationActions.removeLast()
@@ -240,7 +239,7 @@ public class DKChainableAnimationKit {
         }
     }
 
-    internal func addAnimationCompletionAction(action: AnimationCompletionAction) {
+    internal func addAnimationCompletionAction(_ action: @escaping AnimationCompletionAction) {
         if var actions = self.animationCompletionActions.last as [AnimationCompletionAction]? {
             actions.append(action)
             self.animationCompletionActions.removeLast()
@@ -248,11 +247,11 @@ public class DKChainableAnimationKit {
         }
     }
 
-    internal func addAnimationFromCalculationBlock(animation: DKKeyFrameAnimation) {
+    internal func addAnimationFromCalculationBlock(_ animation: DKKeyFrameAnimation) {
         if var animationCluster = self.animations.first {
             animationCluster.append(animation)
-            self.animations.removeAtIndex(0)
-            self.animations.insert(animationCluster, atIndex: 0)
+            self.animations.remove(at: 0)
+            self.animations.insert(animationCluster, at: 0)
         }
     }
 
@@ -262,21 +261,21 @@ public class DKChainableAnimationKit {
         return CAAnimationGroup()
     }
     
-    internal func basicAnimationForKeyPath(keyPath: String) -> DKKeyFrameAnimation {
+    internal func basicAnimationForKeyPath(_ keyPath: String) -> DKKeyFrameAnimation {
         let animation = DKKeyFrameAnimation(keyPath: keyPath)
         animation.repeatCount = 0
         animation.autoreverses = false
         return animation
     }
 
-    internal func newPositionFrom(newOrigin newOrigin: CGPoint) -> CGPoint {
+    internal func newPositionFrom(newOrigin: CGPoint) -> CGPoint {
         let anchor = self.view.layer.anchorPoint
         let size = self.view.bounds.size
         let newPosition = CGPoint(x: newOrigin.x + anchor.x * size.width, y: newOrigin.y + anchor.y * size.height)
         return newPosition
     }
 
-    internal func newPositionFrom(newCenter newCenter: CGPoint) -> CGPoint {
+    internal func newPositionFrom(newCenter: CGPoint) -> CGPoint {
         let anchor = self.view.layer.anchorPoint
         let size = self.view.bounds.size
         let newPosition = CGPoint(x: newCenter.x + (anchor.x - 0.5) * size.width, y: newCenter.y + (anchor.y - 0.5) * size.height)

--- a/DKChainableAnimationKit/Classes/DKKeyFrameAnimation.swift
+++ b/DKChainableAnimationKit/Classes/DKKeyFrameAnimation.swift
@@ -8,7 +8,7 @@
 
 import UIKit
 
-public class DKKeyFrameAnimation: CAKeyframeAnimation {
+open class DKKeyFrameAnimation: CAKeyframeAnimation {
 
     internal let kFPS = 60
 
@@ -30,64 +30,63 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
 
     internal func createValueArray() {
         if let fromValue: AnyObject = self.fromValue, let toValue: AnyObject = self.toValue {
-            if valueIsKindOf(NSNumber) {
+            if valueIsKindOf(NSNumber.self) {
                 self.values = self.valueArrayFor(startValue: CGFloat(fromValue.floatValue), endValue: CGFloat(toValue.floatValue)) as [AnyObject]
-            } else if valueIsKindOf(UIColor) {
-                let fromColor = self.fromValue.CGColor
-                let toColor = self.toValue.CGColor
-                let fromComponents = CGColorGetComponents(fromColor)
-                let toComponents = CGColorGetComponents(toColor)
+            } else if valueIsKindOf(UIColor.self) {
+                let fromColor = self.fromValue.cgColor
+                let toColor = self.toValue.cgColor
+                let fromComponents = fromColor?.components
+                let toComponents = toColor?.components
 
-                let redValues = self.valueArrayFor(startValue: fromComponents[0], endValue: toComponents[0]) as! [CGFloat]
-                let greenValues = self.valueArrayFor(startValue: fromComponents[1], endValue: toComponents[1]) as! [CGFloat]
-                let blueValues = self.valueArrayFor(startValue: fromComponents[2], endValue: toComponents[2]) as! [CGFloat]
-                let alphaValues = self.valueArrayFor(startValue: fromComponents[3], endValue: toComponents[3]) as! [CGFloat]
+                let redValues = self.valueArrayFor(startValue: (fromComponents?[0])!, endValue: (toComponents?[0])!) as! [CGFloat]
+                let greenValues = self.valueArrayFor(startValue: (fromComponents?[1])!, endValue: (toComponents?[1])!) as! [CGFloat]
+                let blueValues = self.valueArrayFor(startValue: (fromComponents?[2])!, endValue: (toComponents?[2])!) as! [CGFloat]
+                let alphaValues = self.valueArrayFor(startValue: (fromComponents?[3])!, endValue: (toComponents?[3])!) as! [CGFloat]
 
                 self.values = self.colorArrayFrom(redValues: redValues, greenValues: greenValues, blueValues: blueValues, alphaValues: alphaValues) as [AnyObject]
-            } else if valueIsKindOf(NSValue) {
-                self.fromValue.objCType
-                let valueType: NSString! = NSString(CString: self.fromValue.objCType, encoding: 1)
-                if valueType.containsString("CGRect") {
-                    let fromRect = self.fromValue.CGRectValue
-                    let toRect = self.toValue.CGRectValue
+            } else if valueIsKindOf(NSValue.self) {
+                let valueType: NSString! = NSString(cString: self.fromValue.objCType, encoding: 1)
+                if valueType.contains("CGRect") {
+                    let fromRect = self.fromValue.cgRectValue
+                    let toRect = self.toValue.cgRectValue
 
-                    let xValues = self.valueArrayFor(startValue: fromRect.origin.x, endValue: toRect.origin.x) as! [CGFloat]
-                    let yValues = self.valueArrayFor(startValue: fromRect.origin.y, endValue: toRect.origin.x) as! [CGFloat]
-                    let widthValues = self.valueArrayFor(startValue: fromRect.size.width, endValue: toRect.size.width) as! [CGFloat]
-                    let heightValues = self.valueArrayFor(startValue: fromRect.size.height, endValue: toRect.size.height) as! [CGFloat]
+                    let xValues = self.valueArrayFor(startValue: (fromRect?.origin.x)!, endValue: (toRect?.origin.x)!) as! [CGFloat]
+                    let yValues = self.valueArrayFor(startValue: (fromRect?.origin.y)!, endValue: (toRect?.origin.x)!) as! [CGFloat]
+                    let widthValues = self.valueArrayFor(startValue: (fromRect?.size.width)!, endValue: (toRect?.size.width)!) as! [CGFloat]
+                    let heightValues = self.valueArrayFor(startValue: (fromRect?.size.height)!, endValue: (toRect?.size.height)!) as! [CGFloat]
 
                     self.values = self.rectArrayFrom(xValues: xValues, yValues: yValues, widthValues: widthValues, heightValues: heightValues) as [AnyObject]
 
-                } else if valueType.containsString("CGPoint") {
-                    let fromPoint = self.fromValue.CGPointValue
-                    let toPoint = self.toValue.CGPointValue
-                    let path = self.createPathFromXYValues(self.valueArrayFor(startValue: fromPoint.x, endValue: toPoint.x), yValues: self.valueArrayFor(startValue: fromPoint.y, endValue: toPoint.y))
+                } else if valueType.contains("CGPoint") {
+                    let fromPoint = self.fromValue.cgPointValue
+                    let toPoint = self.toValue.cgPointValue
+                    let path = self.createPathFromXYValues(self.valueArrayFor(startValue: (fromPoint?.x)!, endValue: (toPoint?.x)!), yValues: self.valueArrayFor(startValue: (fromPoint?.y)!, endValue: (toPoint?.y)!))
                     self.path = path
-                } else if valueType.containsString("CGSize") {
-                    let fromSize = self.fromValue.CGSizeValue()
-                    let toSize = self.toValue.CGSizeValue()
-                    let path = self.createPathFromXYValues(self.valueArrayFor(startValue: fromSize.width, endValue: toSize.width), yValues: self.valueArrayFor(startValue: fromSize.height, endValue: toSize.height))
+                } else if valueType.contains("CGSize") {
+                    let fromSize = self.fromValue.cgSizeValue
+                    let toSize = self.toValue.cgSizeValue
+                    let path = self.createPathFromXYValues(self.valueArrayFor(startValue: (fromSize?.width)!, endValue: (toSize?.width)!), yValues: self.valueArrayFor(startValue: (fromSize?.height)!, endValue: (toSize?.height)!))
                     self.path = path
-                } else if valueType.containsString("CATransform3D") {
-                    let fromTransform = self.fromValue.CATransform3DValue
-                    let toTransform = self.toValue.CATransform3DValue
+                } else if valueType.contains("CATransform3D") {
+                    let fromTransform = self.fromValue.caTransform3DValue
+                    let toTransform = self.toValue.caTransform3DValue
 
-                    let m11 = self.valueArrayFor(startValue: fromTransform.m11, endValue: toTransform.m11)
-                    let m12 = self.valueArrayFor(startValue: fromTransform.m12, endValue: toTransform.m12)
-                    let m13 = self.valueArrayFor(startValue: fromTransform.m13, endValue: toTransform.m13)
-                    let m14 = self.valueArrayFor(startValue: fromTransform.m14, endValue: toTransform.m14)
-                    let m21 = self.valueArrayFor(startValue: fromTransform.m21, endValue: toTransform.m21)
-                    let m22 = self.valueArrayFor(startValue: fromTransform.m22, endValue: toTransform.m22)
-                    let m23 = self.valueArrayFor(startValue: fromTransform.m23, endValue: toTransform.m23)
-                    let m24 = self.valueArrayFor(startValue: fromTransform.m24, endValue: toTransform.m24)
-                    let m31 = self.valueArrayFor(startValue: fromTransform.m31, endValue: toTransform.m31)
-                    let m32 = self.valueArrayFor(startValue: fromTransform.m32, endValue: toTransform.m32)
-                    let m33 = self.valueArrayFor(startValue: fromTransform.m33, endValue: toTransform.m33)
-                    let m34 = self.valueArrayFor(startValue: fromTransform.m34, endValue: toTransform.m34)
-                    let m41 = self.valueArrayFor(startValue: fromTransform.m41, endValue: toTransform.m41)
-                    let m42 = self.valueArrayFor(startValue: fromTransform.m42, endValue: toTransform.m42)
-                    let m43 = self.valueArrayFor(startValue: fromTransform.m43, endValue: toTransform.m43)
-                    let m44 = self.valueArrayFor(startValue: fromTransform.m44, endValue: toTransform.m44)
+                    let m11 = self.valueArrayFor(startValue: (fromTransform?.m11)!, endValue: (toTransform?.m11)!)
+                    let m12 = self.valueArrayFor(startValue: (fromTransform?.m12)!, endValue: (toTransform?.m12)!)
+                    let m13 = self.valueArrayFor(startValue: (fromTransform?.m13)!, endValue: (toTransform?.m13)!)
+                    let m14 = self.valueArrayFor(startValue: (fromTransform?.m14)!, endValue: (toTransform?.m14)!)
+                    let m21 = self.valueArrayFor(startValue: (fromTransform?.m21)!, endValue: (toTransform?.m21)!)
+                    let m22 = self.valueArrayFor(startValue: (fromTransform?.m22)!, endValue: (toTransform?.m22)!)
+                    let m23 = self.valueArrayFor(startValue: (fromTransform?.m23)!, endValue: (toTransform?.m23)!)
+                    let m24 = self.valueArrayFor(startValue: (fromTransform?.m24)!, endValue: (toTransform?.m24)!)
+                    let m31 = self.valueArrayFor(startValue: (fromTransform?.m31)!, endValue: (toTransform?.m31)!)
+                    let m32 = self.valueArrayFor(startValue: (fromTransform?.m32)!, endValue: (toTransform?.m32)!)
+                    let m33 = self.valueArrayFor(startValue: (fromTransform?.m33)!, endValue: (toTransform?.m33)!)
+                    let m34 = self.valueArrayFor(startValue: (fromTransform?.m34)!, endValue: (toTransform?.m34)!)
+                    let m41 = self.valueArrayFor(startValue: (fromTransform?.m41)!, endValue: (toTransform?.m41)!)
+                    let m42 = self.valueArrayFor(startValue: (fromTransform?.m42)!, endValue: (toTransform?.m42)!)
+                    let m43 = self.valueArrayFor(startValue: (fromTransform?.m43)!, endValue: (toTransform?.m43)!)
+                    let m44 = self.valueArrayFor(startValue: (fromTransform?.m44)!, endValue: (toTransform?.m44)!)
 
                     self.values = self.createTransformArrayFrom(
                         m11: m11, m12: m12, m13: m13, m14: m14,
@@ -100,8 +99,8 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
         }
     }
 
-    private func createTransformArrayFrom(
-        m11 m11: NSArray, m12: NSArray, m13: NSArray, m14: NSArray,
+    fileprivate func createTransformArrayFrom(
+        m11: NSArray, m12: NSArray, m13: NSArray, m14: NSArray,
         m21: NSArray, m22: NSArray, m23: NSArray, m24: NSArray,
         m31: NSArray, m32: NSArray, m33: NSArray, m34: NSArray,
         m41: NSArray, m42: NSArray, m43: NSArray, m44: NSArray) -> NSArray {
@@ -110,77 +109,77 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
             var value: CATransform3D!
             for i in 0..<numberOfTransforms {
                 value = CATransform3DIdentity;
-                value.m11 = CGFloat(m11.objectAtIndex(i).floatValue)
-                value.m12 = CGFloat(m12.objectAtIndex(i).floatValue)
-                value.m13 = CGFloat(m13.objectAtIndex(i).floatValue)
-                value.m14 = CGFloat(m14.objectAtIndex(i).floatValue)
+                value.m11 = CGFloat((m11.object(at: i) as AnyObject).floatValue)
+                value.m12 = CGFloat((m12.object(at: i) as AnyObject).floatValue)
+                value.m13 = CGFloat((m13.object(at: i) as AnyObject).floatValue)
+                value.m14 = CGFloat((m14.object(at: i) as AnyObject).floatValue)
 
-                value.m21 = CGFloat(m21.objectAtIndex(i).floatValue)
-                value.m22 = CGFloat(m22.objectAtIndex(i).floatValue)
-                value.m23 = CGFloat(m23.objectAtIndex(i).floatValue)
-                value.m24 = CGFloat(m24.objectAtIndex(i).floatValue)
+                value.m21 = CGFloat((m21.object(at: i) as AnyObject).floatValue)
+                value.m22 = CGFloat((m22.object(at: i) as AnyObject).floatValue)
+                value.m23 = CGFloat((m23.object(at: i) as AnyObject).floatValue)
+                value.m24 = CGFloat((m24.object(at: i) as AnyObject).floatValue)
 
-                value.m31 = CGFloat(m31.objectAtIndex(i).floatValue)
-                value.m32 = CGFloat(m32.objectAtIndex(i).floatValue)
-                value.m33 = CGFloat(m33.objectAtIndex(i).floatValue)
-                value.m44 = CGFloat(m34.objectAtIndex(i).floatValue)
+                value.m31 = CGFloat((m31.object(at: i) as AnyObject).floatValue)
+                value.m32 = CGFloat((m32.object(at: i) as AnyObject).floatValue)
+                value.m33 = CGFloat((m33.object(at: i) as AnyObject).floatValue)
+                value.m44 = CGFloat((m34.object(at: i) as AnyObject).floatValue)
 
-                value.m41 = CGFloat(m41.objectAtIndex(i).floatValue)
-                value.m42 = CGFloat(m42.objectAtIndex(i).floatValue)
-                value.m43 = CGFloat(m43.objectAtIndex(i).floatValue)
-                value.m44 = CGFloat(m44.objectAtIndex(i).floatValue)
+                value.m41 = CGFloat((m41.object(at: i) as AnyObject).floatValue)
+                value.m42 = CGFloat((m42.object(at: i) as AnyObject).floatValue)
+                value.m43 = CGFloat((m43.object(at: i) as AnyObject).floatValue)
+                value.m44 = CGFloat((m44.object(at: i) as AnyObject).floatValue)
 
-                values.addObject(NSValue(CATransform3D: value))
+                values.add(NSValue(caTransform3D: value))
             }
             return values
     }
 
-    private func createPathFromXYValues(xValues: NSArray, yValues: NSArray) -> CGPathRef {
+    fileprivate func createPathFromXYValues(_ xValues: NSArray, yValues: NSArray) -> CGPath {
         let numberOfPoints = xValues.count
-        let path = CGPathCreateMutable()
+        let path = CGMutablePath()
         var value = CGPoint(
-            x: CGFloat(xValues.objectAtIndex(0).floatValue),
-            y: CGFloat(yValues.objectAtIndex(0).floatValue))
-        CGPathMoveToPoint(path, nil, value.x, value.y)
+            x: CGFloat((xValues.object(at: 0) as AnyObject).floatValue),
+            y: CGFloat((yValues.object(at: 0) as AnyObject).floatValue))
+        path.move(to: value)
         for i in 1..<numberOfPoints {
             value = CGPoint(
-                x: CGFloat(xValues.objectAtIndex(i).floatValue),
-                y: CGFloat(yValues.objectAtIndex(i).floatValue))
-            CGPathAddLineToPoint(path, nil, value.x, value.y)
+                x: CGFloat((xValues.object(at: i) as AnyObject).floatValue),
+                y: CGFloat((yValues.object(at: i) as AnyObject).floatValue))
+            path.move(to: value)
         }
         return path
     }
 
-    private func valueIsKindOf(klass: AnyClass) -> Bool {
-        return self.fromValue.isKindOfClass(klass) && self.toValue.isKindOfClass(klass)
+    fileprivate func valueIsKindOf(_ klass: AnyClass) -> Bool {
+        return self.fromValue.isKind(of: klass) && self.toValue.isKind(of: klass)
     }
 
-    private func rectArrayFrom(xValues xValues: [CGFloat], yValues: [CGFloat], widthValues: [CGFloat], heightValues: [CGFloat]) -> NSArray {
+    fileprivate func rectArrayFrom(xValues: [CGFloat], yValues: [CGFloat], widthValues: [CGFloat], heightValues: [CGFloat]) -> NSArray {
         let numberOfRects = xValues.count
         let values: NSMutableArray = []
         var value: NSValue
 
         for i in 1..<numberOfRects {
-            value = NSValue(CGRect: CGRect(x: xValues[i], y: yValues[i], width: widthValues[i], height: heightValues[i]))
-            values.addObject(value)
+            value = NSValue(cgRect: CGRect(x: xValues[i], y: yValues[i], width: widthValues[i], height: heightValues[i]))
+            values.add(value)
         }
         return values
 
     }
 
-    private func colorArrayFrom(redValues redValues: [CGFloat], greenValues: [CGFloat], blueValues: [CGFloat], alphaValues: [CGFloat]) -> [CGColor] {
+    fileprivate func colorArrayFrom(redValues: [CGFloat], greenValues: [CGFloat], blueValues: [CGFloat], alphaValues: [CGFloat]) -> [CGColor] {
         let numberOfColors = redValues.count
         var values: [CGColor] = []
         var value: CGColor!
 
         for i in 1..<numberOfColors {
-            value = UIColor(red: redValues[i], green: greenValues[i], blue: blueValues[i], alpha: alphaValues[i]).CGColor
+            value = UIColor(red: redValues[i], green: greenValues[i], blue: blueValues[i], alpha: alphaValues[i]).cgColor
             values.append(value)
         }
         return values
     }
 
-    private func valueArrayFor(startValue startValue: CGFloat, endValue: CGFloat) -> NSArray {
+    fileprivate func valueArrayFor(startValue: CGFloat, endValue: CGFloat) -> NSArray {
         let startValue = Double(startValue)
         let endValue = Double(endValue)
 
@@ -200,7 +199,7 @@ public class DKKeyFrameAnimation: CAKeyframeAnimation {
             progress += increment
         }
 
-        return valueArray
+        return valueArray as NSArray
     }
 
 }

--- a/DKChainableAnimationKit/Classes/DKKeyframeAnimationFunction.swift
+++ b/DKChainableAnimationKit/Classes/DKKeyframeAnimationFunction.swift
@@ -10,22 +10,22 @@ import UIKit
 
 typealias DKKeyframeAnimationFunctionBlock = (Double, Double, Double, Double) -> Double
 
-func DKKeyframeAnimationFunctionLinear(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionLinear(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return c * t + b
 }
 
-func DKKeyframeAnimationFunctionEaseInQuad(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInQuad(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return c * t * t + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutQuad(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutQuad(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return -c * t * (t - 2) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutQuad(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutQuad(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var t = t / (d / 2)
     if t < 1 {
         return c / 2 * t * t + b;
@@ -34,17 +34,17 @@ func DKKeyframeAnimationFunctionEaseInOutQuad(t: Double, b: Double, c: Double, d
     return -c / 2 * ((t) * (t - 2) - 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInCubic(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInCubic(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return c * t * t * t + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutCubic(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutCubic(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d - 1
     return c * (t * t * t + 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutCubic(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutCubic(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var t = t / (d / 2)
     if t < 1 {
         return c / 2 * t * t * t + b;
@@ -54,17 +54,17 @@ func DKKeyframeAnimationFunctionEaseInOutCubic(t: Double, b: Double, c: Double, 
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInQuart(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInQuart(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return c * t * t * t * t + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutQuart(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutQuart(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d - 1
     return -c * (t * t * t * t - 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutQuart(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutQuart(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var t = t / (d / 2)
     if t < 1 {
         return c / 2 * t * t * t * t + b;
@@ -74,17 +74,17 @@ func DKKeyframeAnimationFunctionEaseInOutQuart(t: Double, b: Double, c: Double, 
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInQuint(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInQuint(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return c * t * t * t * t * t + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutQuint(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutQuint(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d - 1
     return c * (t * t * t * t * t + 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutQuint(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutQuint(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var t = t / (d / 2)
     if t < 1 {
         return c / 2 * t * t * t * t * t + b;
@@ -94,28 +94,28 @@ func DKKeyframeAnimationFunctionEaseInOutQuint(t: Double, b: Double, c: Double, 
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInSine(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInSine(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     return -c * cos(t / d * (M_PI_2)) + c + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutSine(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutSine(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     return c * sin(t / d * (M_PI_2)) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutSine(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutSine(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     return -c / 2 * (cos(M_PI * t / d) - 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInExpo(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInExpo(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     return (t==0) ? b : c * pow(2, 10 * (t / d - 1)) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutExpo(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutExpo(_ t: Double, b: Double, c: Double, d: Double) -> Double {
 
     return (t == d) ? b+c : c * (-pow(2, -10 * t / d) + 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutExpo(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutExpo(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     if t == 0 {
         return b
     }
@@ -130,17 +130,17 @@ func DKKeyframeAnimationFunctionEaseInOutExpo(t: Double, b: Double, c: Double, d
     return c / 2 * (-pow(2, -10 * t) + 2) + b
 }
 
-func DKKeyframeAnimationFunctionEaseInCirc(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInCirc(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d
     return -c * (sqrt(1 - t * t) - 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutCirc(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutCirc(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let t = t / d - 1
     return c * sqrt(1 - t * t) + b
 }
 
-func DKKeyframeAnimationFunctionEaseInOutCirc(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutCirc(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var t = t / (d / 2)
     if t < 1 {
         return -c / 2 * (sqrt(1 - t * t) - 1) + b
@@ -149,7 +149,7 @@ func DKKeyframeAnimationFunctionEaseInOutCirc(t: Double, b: Double, c: Double, d
     return c / 2 * (sqrt(1 - t * t) + 1) + b
 }
 
-func DKKeyframeAnimationFunctionEaseInElastic(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInElastic(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var s = 1.70158
     var p = 0.0
     var a = c
@@ -174,7 +174,7 @@ func DKKeyframeAnimationFunctionEaseInElastic(t: Double, b: Double, c: Double, d
     return -(a * pow(2, 10 * t) * sin((t * d - s) * (2 * M_PI) / p )) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutElastic(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutElastic(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var s = 1.70158
     var p = 0.0
     var a = c
@@ -198,7 +198,7 @@ func DKKeyframeAnimationFunctionEaseOutElastic(t: Double, b: Double, c: Double, 
     return (a * pow(2, 10 * t) * sin((t * d - s) * (2 * M_PI) / p)) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutElastic(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutElastic(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var s = 1.70158
     var p = 0.0
     var a = c;
@@ -228,19 +228,19 @@ func DKKeyframeAnimationFunctionEaseInOutElastic(t: Double, b: Double, c: Double
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInBack(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInBack(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let s = 1.70158
     let t = t / d
     return c * t * t * ((s + 1) * t - s) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutBack(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutBack(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     let s = 1.70158
     let t = t / d - 1
     return c * (t * t * ((s + 1) * t + s) + 1) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseInOutBack(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutBack(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var s = 1.70158
     var t = t / (d / 2)
 
@@ -254,11 +254,11 @@ func DKKeyframeAnimationFunctionEaseInOutBack(t: Double, b: Double, c: Double, d
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInBounce(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInBounce(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     return c - DKKeyframeAnimationFunctionEaseOutBounce(d - t, b: 0, c: c, d: d) + b;
 }
 
-func DKKeyframeAnimationFunctionEaseOutBounce(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseOutBounce(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     var t = t / d
     if t < 1 / 2.75 {
         return c * (7.5625 * t * t) + b;
@@ -274,7 +274,7 @@ func DKKeyframeAnimationFunctionEaseOutBounce(t: Double, b: Double, c: Double, d
     }
 }
 
-func DKKeyframeAnimationFunctionEaseInOutBounce(t: Double, b: Double, c: Double, d: Double) -> Double {
+func DKKeyframeAnimationFunctionEaseInOutBounce(_ t: Double, b: Double, c: Double, d: Double) -> Double {
     if t < d / 2 {
         return DKKeyframeAnimationFunctionEaseInBounce (t * 2, b: 0, c: c, d: d) * 0.5 + b;
     } else {

--- a/DKChainableAnimationKit/Classes/UIView+AnimationKit.swift
+++ b/DKChainableAnimationKit/Classes/UIView+AnimationKit.swift
@@ -28,7 +28,7 @@ public extension UIView {
 
     final public func bezierPathForAnimation() -> UIBezierPath {
         let path = UIBezierPath()
-        path.moveToPoint(self.layer.position)
+        path.move(to: self.layer.position)
         return path
     }
 

--- a/DKChainableAnimationKitTests/DKChainableAnimationKitTests.swift
+++ b/DKChainableAnimationKitTests/DKChainableAnimationKitTests.swift
@@ -28,7 +28,7 @@ class DKChainableAnimationKitTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/iOS Example Tests/DKChainableAnimationKitTests.swift
+++ b/iOS Example Tests/DKChainableAnimationKitTests.swift
@@ -28,7 +28,7 @@ class DKChainableAnimationKitTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock() {
+        self.measure() {
             // Put the code you want to measure the time of here.
         }
     }

--- a/iOS Example.xcodeproj/project.pbxproj
+++ b/iOS Example.xcodeproj/project.pbxproj
@@ -208,14 +208,16 @@
 			isa = PBXProject;
 			attributes = {
 				LastSwiftUpdateCheck = 0700;
-				LastUpgradeCheck = 0700;
+				LastUpgradeCheck = 0800;
 				ORGANIZATIONNAME = DeltaX;
 				TargetAttributes = {
 					18CEB5BB1B059B0300B6ACCB = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 					};
 					18CEB5D01B059B0300B6ACCB = {
 						CreatedOnToolsVersion = 6.3;
+						LastSwiftMigration = 0800;
 						TestTargetID = 18CEB5BB1B059B0300B6ACCB;
 					};
 				};
@@ -348,8 +350,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -393,8 +397,10 @@
 				CLANG_WARN_DIRECT_OBJC_ISA_USAGE = YES_ERROR;
 				CLANG_WARN_EMPTY_BODY = YES;
 				CLANG_WARN_ENUM_CONVERSION = YES;
+				CLANG_WARN_INFINITE_RECURSION = YES;
 				CLANG_WARN_INT_CONVERSION = YES;
 				CLANG_WARN_OBJC_ROOT_CLASS = YES_ERROR;
+				CLANG_WARN_SUSPICIOUS_MOVE = YES;
 				CLANG_WARN_UNREACHABLE_CODE = YES;
 				CLANG_WARN__DUPLICATE_METHOD_MATCH = YES;
 				"CODE_SIGN_IDENTITY[sdk=iphoneos*]" = "iPhone Developer";
@@ -413,6 +419,7 @@
 				IPHONEOS_DEPLOYMENT_TARGET = 8.0;
 				MTL_ENABLE_DEBUG_INFO = NO;
 				SDKROOT = iphoneos;
+				SWIFT_OPTIMIZATION_LEVEL = "-Owholemodule";
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -426,6 +433,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS Example";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -438,6 +446,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS Example";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -457,6 +466,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS ExampleTests";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example.app/iOS Example";
 			};
 			name = Debug;
@@ -473,6 +483,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/Frameworks @loader_path/Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "com.draveness.$(PRODUCT_NAME:rfc1034identifier)";
 				PRODUCT_NAME = "iOS ExampleTests";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/iOS Example.app/iOS Example";
 			};
 			name = Release;

--- a/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
+++ b/iOS Example.xcodeproj/xcshareddata/xcschemes/iOS Example.xcscheme
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Scheme
-   LastUpgradeVersion = "0700"
+   LastUpgradeVersion = "0800"
    version = "1.3">
    <BuildAction
       parallelizeBuildables = "YES"

--- a/iOS Example/AppDelegate.swift
+++ b/iOS Example/AppDelegate.swift
@@ -14,30 +14,30 @@ class AppDelegate: UIResponder, UIApplicationDelegate {
     var window: UIWindow?
 
 
-    func application(application: UIApplication, didFinishLaunchingWithOptions launchOptions: [NSObject: AnyObject]?) -> Bool {
+    func application(_ application: UIApplication, didFinishLaunchingWithOptions launchOptions: [UIApplicationLaunchOptionsKey: Any]?) -> Bool {
         // Override point for customization after application launch.
         return true
     }
 
-    func applicationWillResignActive(application: UIApplication) {
+    func applicationWillResignActive(_ application: UIApplication) {
         // Sent when the application is about to move from active to inactive state. This can occur for certain types of temporary interruptions (such as an incoming phone call or SMS message) or when the user quits the application and it begins the transition to the background state.
         // Use this method to pause ongoing tasks, disable timers, and throttle down OpenGL ES frame rates. Games should use this method to pause the game.
     }
 
-    func applicationDidEnterBackground(application: UIApplication) {
+    func applicationDidEnterBackground(_ application: UIApplication) {
         // Use this method to release shared resources, save user data, invalidate timers, and store enough application state information to restore your application to its current state in case it is terminated later.
         // If your application supports background execution, this method is called instead of applicationWillTerminate: when the user quits.
     }
 
-    func applicationWillEnterForeground(application: UIApplication) {
+    func applicationWillEnterForeground(_ application: UIApplication) {
         // Called as part of the transition from the background to the inactive state; here you can undo many of the changes made on entering the background.
     }
 
-    func applicationDidBecomeActive(application: UIApplication) {
+    func applicationDidBecomeActive(_ application: UIApplication) {
         // Restart any tasks that were paused (or not yet started) while the application was inactive. If the application was previously in the background, optionally refresh the user interface.
     }
 
-    func applicationWillTerminate(application: UIApplication) {
+    func applicationWillTerminate(_ application: UIApplication) {
         // Called when the application is about to terminate. Save data if appropriate. See also applicationDidEnterBackground:.
     }
 

--- a/iOS Example/ViewController.swift
+++ b/iOS Example/ViewController.swift
@@ -47,7 +47,7 @@ class ViewController: UIViewController {
             };
         })
 
-       _ = sender.animation.moveY(50).easeInOutExpo.animate(0.5)
+       sender.animation.moveY(50).easeInOutExpo.animate(0.5)
 
     }
 }

--- a/iOS Example/ViewController.swift
+++ b/iOS Example/ViewController.swift
@@ -16,38 +16,38 @@ class ViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
 
-        v.backgroundColor = UIColor.blueColor()
+        v.backgroundColor = UIColor.blue
         self.view.addSubview(v)
 
-        UIApplication.sharedApplication().statusBarHidden = true
+        UIApplication.shared.isStatusBarHidden = true
 
         let button = UIButton(frame: CGRect(x: 0, y: 0, width: 50, height: 50))
         button.frame = CGRect(x: 0, y: self.view.bounds.size.height - 50.0, width: self.view.bounds.size.width, height: 50)
-        button.backgroundColor = UIColor.blueColor()
-        button.setTitle("Action!", forState: .Normal)
-        button.setTitleColor(UIColor.whiteColor(), forState: .Normal)
-        button.addTarget(self, action: #selector(ViewController.animateView(_:)), forControlEvents: .TouchUpInside)
+        button.backgroundColor = UIColor.blue
+        button.setTitle("Action!", for: UIControlState.normal)
+        button.setTitleColor(UIColor.white, for: UIControlState.normal)
+        button.addTarget(self, action: #selector(ViewController.animateView(_:)), for: .touchUpInside)
         self.view.addSubview(button)
     }
 
-    func animateView(sender: UIButton) {
-        sender.userInteractionEnabled = false
-        _ = UIColor.purpleColor()
-        let green = UIColor.greenColor()
+    func animateView(_ sender: UIButton) {
+        sender.isUserInteractionEnabled = false
+        _ = UIColor.purple
+        let green = UIColor.green
 
         v.animation.moveX(100).thenAfter(1.0).moveWidth(50).bounce.makeBackground(green).easeIn.anchorTopLeft.thenAfter(0.5).rotate(95).easeBack.thenAfter(0.5).moveY(300).easeIn.makeOpacity(0.0).animateWithCompletion(0.4, {
             self.v.layer.transform = CATransform3DMakeRotation(0, 0, 0, 1)
-            self.v.frame = CGRectMake(100, 150, 50, 50)
-            self.v.animation.makeOpacity(1.0).makeBackground(UIColor.blueColor()).animate(1.0)
+            self.v.frame = CGRect(x: 100, y: 150, width: 50, height: 50)
+            self.v.animation.makeOpacity(1.0).makeBackground(UIColor.blue).animate(1.0)
             self.v.layer.cornerRadius = 0
 
 
             sender.animation.moveY(-50).easeInOutExpo.animate(1.1).animationCompletion = {
-                sender.userInteractionEnabled = true
+                sender.isUserInteractionEnabled = true
             };
         })
 
-        sender.animation.moveY(50).easeInOutExpo.animate(0.5)
+       _ = sender.animation.moveY(50).easeInOutExpo.animate(0.5)
 
     }
 }


### PR DESCRIPTION
I used the swift converter in Xcode. That fixed most of the issues, there where some manual ones like casting the DKKeyFrameAnimation's fromValue and toValue assignment, adding the `@discardableResult` directive to the public animation functions (animate and animateWithCompletion) because this now produces a warning. Unfortunately you can't add the `@discardarbleResult` directive to properties so I simply used the `_ =` to suppress the warnings. There were a couple of other minor things here and there. Fixed the iOS Example and everything seems to be working.
