### PR TITLE
Fixed make background to work with monotone colors in iOS 10

### DIFF
--- a/DKChainableAnimationKit/Classes/DKKeyFrameAnimation.swift
+++ b/DKChainableAnimationKit/Classes/DKKeyFrameAnimation.swift
@@ -33,15 +33,43 @@ open class DKKeyFrameAnimation: CAKeyframeAnimation {
             if valueIsKindOf(NSNumber.self) {
                 self.values = self.valueArrayFor(startValue: CGFloat(fromValue.floatValue), endValue: CGFloat(toValue.floatValue)) as [AnyObject]
             } else if valueIsKindOf(UIColor.self) {
-                let fromColor = self.fromValue.cgColor
-                let toColor = self.toValue.cgColor
-                let fromComponents = fromColor?.components
-                let toComponents = toColor?.components
+                guard let fromColor = self.fromValue.cgColor else { fatalError("Could not extract CGColor") }
+                guard let toColor = self.toValue.cgColor else { fatalError("Could not extract CGColor") }
+                guard let fromComponents = fromColor.components else { fatalError("Could not extract color components") }
+                guard let toComponents = toColor.components else { fatalError("Could not extract color components") }
 
-                let redValues = self.valueArrayFor(startValue: (fromComponents?[0])!, endValue: (toComponents?[0])!) as! [CGFloat]
-                let greenValues = self.valueArrayFor(startValue: (fromComponents?[1])!, endValue: (toComponents?[1])!) as! [CGFloat]
-                let blueValues = self.valueArrayFor(startValue: (fromComponents?[2])!, endValue: (toComponents?[2])!) as! [CGFloat]
-                let alphaValues = self.valueArrayFor(startValue: (fromComponents?[3])!, endValue: (toComponents?[3])!) as! [CGFloat]
+                let red, green, blue: (start: CGFloat, end: CGFloat)
+                let alphaStart = fromComponents.last
+                let alphaEnd = toComponents.last
+
+                let numberOfComponentsInMonotoneColor = 2
+
+                switch fromColor.numberOfComponents {
+                case numberOfComponentsInMonotoneColor:
+                    red.start = fromComponents[0]
+                    green.start = fromComponents[0]
+                    blue.start = fromComponents[0]
+                default:
+                    red.start = fromComponents[0]
+                    green.start = fromComponents[1]
+                    blue.start = fromComponents[2]
+                }
+
+                switch toColor.numberOfComponents {
+                case numberOfComponentsInMonotoneColor:
+                    red.end = toComponents[0]
+                    green.end = toComponents[0]
+                    blue.end = toComponents[0]
+                default:
+                    red.end = toComponents[0]
+                    green.end = toComponents[1]
+                    blue.end = toComponents[2]
+                }
+
+                let redValues = self.valueArrayFor(startValue: red.start, endValue: red.end) as! [CGFloat]
+                let greenValues = self.valueArrayFor(startValue: green.start, endValue: green.end) as! [CGFloat]
+                let blueValues = self.valueArrayFor(startValue: blue.start, endValue: blue.end) as! [CGFloat]
+                let alphaValues = self.valueArrayFor(startValue: alphaStart!, endValue: alphaEnd!) as! [CGFloat]
 
                 self.values = self.colorArrayFrom(redValues: redValues, greenValues: greenValues, blueValues: blueValues, alphaValues: alphaValues) as [AnyObject]
             } else if valueIsKindOf(NSValue.self) {

--- a/iOS Example/ViewController.swift
+++ b/iOS Example/ViewController.swift
@@ -12,12 +12,18 @@ import DKChainableAnimationKit
 class ViewController: UIViewController {
 
     let v: UIView = UIView(frame: CGRect(x: 100, y: 150, width: 50, height: 50))
+    let secondView: UIView = UIView(frame: CGRect(x: 300, y: 250, width: 50, height: 50))
 
     override func viewDidLoad() {
         super.viewDidLoad()
 
         v.backgroundColor = UIColor.blue
         self.view.addSubview(v)
+
+        secondView.backgroundColor = UIColor.white
+        secondView.layer.borderWidth = 1.0
+        secondView.layer.borderColor = UIColor.red.cgColor
+        self.view.addSubview(secondView)
 
         UIApplication.shared.isStatusBarHidden = true
 
@@ -34,6 +40,14 @@ class ViewController: UIViewController {
         sender.isUserInteractionEnabled = false
         _ = UIColor.purple
         let green = UIColor.green
+        let black = UIColor.black
+        let white = UIColor.white
+
+        secondView.animation.moveY(-200).makeBackground(black).thenAfter(0.5)
+            .moveY(200).makeBackground(green).thenAfter(0.5)
+            .makeBackground(white).thenAfter(0.2)
+            .makeBackground(black).thenAfter(0.2)
+            .makeBackground(white).animate(0.2)
 
         v.animation.moveX(100).thenAfter(1.0).moveWidth(50).bounce.makeBackground(green).easeIn.anchorTopLeft.thenAfter(0.5).rotate(95).easeBack.thenAfter(0.5).moveY(300).easeIn.makeOpacity(0.0).animateWithCompletion(0.4, {
             self.v.layer.transform = CATransform3DMakeRotation(0, 0, 0, 1)


### PR DESCRIPTION
Converts the 2 components of the monotone colors convenience initializers to 4 while keeping the same behavior when using other initializers. fixes #24 
